### PR TITLE
fix(util): enable namify to remove an absolute path with special chars

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -25,6 +25,7 @@ var CRAZY_SLASHES = new RegExp('\\\\', 'g');
 var ROOT_DIR = new RegExp('^[^\\' + path.sep + ']*\\' + path.sep);
 var ALL_SEPARATORS = new RegExp('\\' + path.sep, 'g');
 var LEADING_SEPARATOR = new RegExp('^\\' + path.sep);
+var SPECIAL_CHARACTERS = /[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g;
 
 
 exports.isAbsolutePath = function isAbsolutePath(file) {
@@ -35,6 +36,9 @@ exports.isAbsolutePath = function isAbsolutePath(file) {
 exports.nameify = function nameify(file, views, ext) {
     // Windows. Ugh.
     views = views && views.replace(CRAZY_SLASHES, '\\\\');
+
+    // Escape special characters in path
+    views = views && views.replace(SPECIAL_CHARACTERS, "\\$&");
 
     // Remove absolute path (if necessary)
     file = file.replace(new RegExp('^' + views), '');

--- a/test/utils.js
+++ b/test/utils.js
@@ -99,6 +99,10 @@ describe('utils', function () {
                 args: [ sysroot + path.join('views', 'inc', 'template.js'), sysroot + path.join('views', 'inc') ],
                 out: 'template.js'
             },
+            'support optional absolute views dir with special characters': {
+                args: [ sysroot + path.join('build adaro (pull request)', 'views', 'inc', 'template.js'), sysroot + path.join('build adaro (pull request)', 'views', 'inc') ],
+                out: 'template.js'
+            },
             'not support relative file with absolute views dir': {
                 args: [ path.join('views', 'inc', 'template.js'), sysroot + path.join('views', 'inc') ],
                 out: 'views/inc/template.js'
@@ -138,7 +142,6 @@ describe('utils', function () {
         });
 
     });
-
 
     describe('resolveViewDir', function () {
 


### PR DESCRIPTION
Whenever adaro tries to remove an absolute path containing special characters (e.g. parenthesis) it fails and hence is not able to render the template.
- escaped special chars before trying to remove the absolute path
- supplied a test that should fail without the fix (and pass with it)
