### PR TITLE
Support for inline function

### DIFF
--- a/lib/reqwire.js
+++ b/lib/reqwire.js
@@ -28,6 +28,9 @@ var reqwire = module.exports = function (/*modules*/) {
     failed = [];
 
     Array.prototype.slice.call(arguments).some(function (moduleName) {
+        if (typeof moduleName === 'function') {
+            return moduleName.apply(null, arguments);
+        }
         try {
             result = freshy(moduleName);
         } catch (err) {


### PR DESCRIPTION
This allows inlining a helper function directly in the configuration, which at the very least is good for providing simple examples.
