### PR TITLE
Added possibility to use multiple views folders

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -34,14 +34,21 @@ exports.isAbsolutePath = function isAbsolutePath(file) {
 
 
 exports.nameify = function nameify(file, views, ext) {
-    // Windows. Ugh.
-    views = views && views.replace(CRAZY_SLASHES, '\\\\');
+    // If single view folder used
+    if(typeof views === 'string') {
+        views = [views];
+    }
 
-    // Escape special characters in path
-    views = views && views.replace(REGEX_SPECIAL_CHARACTERS, "\\$&");
+    for(var i in views) {
+        // Windows. Ugh.
+        views[i] = views[i] && views[i].replace(CRAZY_SLASHES, '\\\\');
 
-    // Remove absolute path (if necessary)
-    file = file.replace(new RegExp('^' + views), '');
+        // Escape special characters in path
+        views[i] = views[i] && views[i].replace(REGEX_SPECIAL_CHARACTERS, "\\$&");
+
+        // Remove absolute path (if necessary)
+        file = file.replace(new RegExp('^' + views[i]), '');
+    }
 
     // Remove file extension
     file = file.replace(ext, '');

--- a/test/utils.js
+++ b/test/utils.js
@@ -100,8 +100,12 @@ describe('utils', function () {
                 out: 'template.js'
             },
             'support optional absolute views dirs': {
-                args: [ sysroot + path.join('views', 'inc', 'template.js'), [sysroot + path.join('views', 'inc'), sysroot + path.join('views', 'inc')]],
+                args: [ sysroot + path.join('views', 'inc', 'template.js'), [sysroot + path.join('views', 'inc'), sysroot + path.join('views_other_dir', 'inc')]],
                 out: 'template.js'
+            },
+            'support optional absolute views dirs_another_dir': {
+                args: [ sysroot + path.join('views_other_dir', 'inc', 'another_template.js'), [sysroot + path.join('views', 'inc'), sysroot + path.join('views_other_dir', 'inc')]],
+                out: 'another_template.js'
             },
             'support optional absolute views dir with special characters': {
                 args: [ sysroot + path.join('build adaro (pull request)', 'views', 'inc', 'template.js'), sysroot + path.join('build adaro (pull request)', 'views', 'inc') ],

--- a/test/utils.js
+++ b/test/utils.js
@@ -99,6 +99,10 @@ describe('utils', function () {
                 args: [ sysroot + path.join('views', 'inc', 'template.js'), sysroot + path.join('views', 'inc') ],
                 out: 'template.js'
             },
+            'support optional absolute views dirs': {
+                args: [ sysroot + path.join('views', 'inc', 'template.js'), [sysroot + path.join('views', 'inc'), sysroot + path.join('views', 'inc')]],
+                out: 'template.js'
+            },
             'support optional absolute views dir with special characters': {
                 args: [ sysroot + path.join('build adaro (pull request)', 'views', 'inc', 'template.js'), sysroot + path.join('build adaro (pull request)', 'views', 'inc') ],
                 out: 'template.js'


### PR DESCRIPTION
I have added possibility for using multiple views folders. For load template we use this function:

``` javascript
adaro.onLoad = function load(name, context, cb) {
        var views, ext, file;

        views = utils.resolveViewDir(context.global);

        ext = context.global.ext || path.extname(name);
        if (ext[0] !== '.') {
            ext = '.' + ext;
        }

        if(typeof views === 'object') {
            for(var i in views) {
                file = path.join(views[i], name + ext);
                if(fs.existsSync(file)) {
                    fs.readFile(file, 'utf8', cb);
                }
            }
        } else {
            file = path.join(views, name + ext);
            fs.readFile(file, 'utf8', cb);
        }
    };
```
