### PR TITLE
dust-intl helper support requested in adaro 1.x

### DIFF
--- a/lib/reqwire.js
+++ b/lib/reqwire.js
@@ -43,7 +43,7 @@ var reqwire = module.exports = function (/*modules*/) {
 
 
 reqwire.init = function (/*name, args...*/) {
-    var args, name, fn;
+    var args, name, helper;
 
     args = Array.prototype.slice.call(arguments);
     name = args.shift();
@@ -52,10 +52,13 @@ reqwire.init = function (/*name, args...*/) {
         name = path.join(process.cwd(), name);
     }
 
-    fn = reqwire(name); // Should be a dependency of the parent app
-    if (typeof fn === 'function') {
+    helper = reqwire(name); // Should be a dependency of the parent app
+    if (typeof helper === 'function') {
         // Handle API that returns an initialization function. Otherwise, assume
         // it conforms to the same pattern as dustjs-helpers.
-        fn.apply(undefined, args);
+        helper.apply(undefined, args);
+    } else if (typeof helper === 'object' && typeof helper.registerWith === 'function') {
+        // Handle API that returns an object with a registerWith function.
+        helper.registerWith.apply(undefined, args);
     }
 };


### PR DESCRIPTION
This change is to support using dust-intl helpers from https://github.com/yahoo/dust-intl with adaro 1.x.  The main file of the dust-intl library can be loaded by calling the registerWith function on the module once it has been required via the reqwire module of adaro.  

Without this change, the reqwire.init function skips the dust-intl module during initialization of dust.helpers, because it currently only expects an IIFE that accepts one parameter (the dust module) and the following markup would fail silently.

``` html
<h2>{@formatMessage _key="some.key"/}</h2>
```

For your reference, please see file snippets below to see additional details of a Kraken.js 2.x project working with dust-intl helpers, using a fork of adaro 1.x with the change in this pull request.

``` json
# package.json
"dependencies": {

    "dust-intl": "~1.1.0",
    "dustjs-helpers": "~1.6.3",
    "dustjs-linkedin": "~2.7.0",
    "intl": "~1.0.1",
    "intl-messageformat": "~1.1.0",
    "kraken-js": "~2.0.0",
    "makara": "~2.0.0",

},
```

``` json
# config.json

"dust": {
   "helpers": [
       "dustjs-helpers",
       "dust-intl"
   ]
},

"view engines": {
    "js": {
         "module": "makara",
         "renderer": {
             "method": "js",
             "arguments": [
                 { "cache": false, "helpers": "config:dust.helpers" }
             ]
         }
    }
},

"middleware": {
    "expressView": {
        "priority": 100,
        "enabled": true,
        "module": {
            "name": "makara",
            "arguments": [
                {
                    "specialization": "config:specialization"
                }
            ]
        }
    }
}
```

``` json
# development.json

"view engines": {
    "dust": {
         "module": "makara",
         "renderer": {
             "method": "dust",
             "arguments": [
                 { "cache": false, "helpers": "config:dust.helpers" }
             ]
         }
    }
}
```
