### PR TITLE
fix documentation for setting adaro.dust() as express view engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ var options = {
   ]
 };
 
-app.engine('dust', adaro(options));
+app.engine('dust', adaro.dust(options));
 app.set('view engine', 'dust');
 
 // For rendering precompiled templates:


### PR DESCRIPTION
The example in the current documentation would throw an error ... TypeError: adaro is not a function

`app.engine('dust', adaro(options));` should be `adaro.dust(options)`

This PR fix that little typo.
