### PR TITLE
Add support for multiple view folders

### DIFF
--- a/lib/engine.js
+++ b/lib/engine.js
@@ -73,15 +73,31 @@ exports.create = function (type, config) {
                 if (path.extname(name) !== options.ext) {
                     f += options.ext;
                 }
-                // Fixme: handle multiple directories.
-                var candidate = path.resolve(options.views, f);
-                fs.stat(candidate, function (err, stat) {
-                    if (err) {
-                        return cb(err);
-                    }
 
-                    read(err, candidate, name);
+                locate(options.views, (err, candidate, name) => {
+                  if (err) {
+                      return cb(err);
+                  }
+
+                  read(err, candidate, name);
                 });
+            }
+
+            // Look in all view directories
+            function locate(views, callback) {
+              if(!Array.isArray(views)) views = [views];
+              var candidate = path.resolve(views[0], f);
+              fs.stat(candidate, function (err, stat) {
+                  if (err) {
+                      if (views.length > 0) {
+                          return locate(views.slice(1), callback);
+                      } else {
+                          return callback(err);
+                      }
+                  }
+
+                  return callback(err, candidate, name);
+              });
             }
 
             function read(err, file, name) {

--- a/lib/engine.js
+++ b/lib/engine.js
@@ -74,7 +74,7 @@ exports.create = function (type, config) {
                     f += options.ext;
                 }
 
-                locate(options.views, (err, candidate, name) => {
+                locate(options.views, function(err, candidate, name) {
                   if (err) {
                       return cb(err);
                   }

--- a/lib/engine.js
+++ b/lib/engine.js
@@ -85,7 +85,9 @@ exports.create = function (type, config) {
 
             // Look in all view directories
             function locate(views, callback) {
-              if(!Array.isArray(views)) views = [views];
+              if(!Array.isArray(views)) {
+                views = [views];
+              }
               var candidate = path.resolve(views[0], f);
               fs.stat(candidate, function (err, stat) {
                   if (err) {


### PR DESCRIPTION
This PR addresses the [fixme](https://github.com/krakenjs/adaro/blob/v1.x/lib/engine.js#L76) in `engine.js` by adding support for multiple view folders as [introduced in Express 4.10](https://github.com/expressjs/express/pull/2320).

The solution looks for a matching template in all folders defined by `app.set('views')`. Checks run in serial to ensure consistent behavior, starting with the first folder and ending with the last.

### Use Cases

One use case for this allows users to set a fallback directory in case a template is missing.

My personal use case is for [Postleaf](https://github.com/Postleaf/postleaf), where users can create their own themes and, if a template is missing, we fall back to a system template in a different location. Postleaf also uses this feature to support rendering admin views and theme views from a single app instance.

### Tests

I'm not super familiar with Mocha, but I ran the tests and all 75 are passing. ✅ 

It may be worth creating a new test for this patch, though. Maybe a maintainer could point me in the right direction?